### PR TITLE
[JOSS review] added DOI for Stehfest 1970 reference

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -51,5 +51,6 @@ journal="Communication of the ACM",
 year="1970",
 volume="13",
 number="1",
-pages="47-49"
+pages="47-49",
+doi="10.1145/361953.361969"
 }


### PR DESCRIPTION
A DOI was missing for the Stehfest 1970 reference. This PR adds it.